### PR TITLE
Fix installation command (added version tag).

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Accept Interfaces, Return Concrete Types
 You can get `ireturn` with `go install` command.
 
 ```shell
-go install github.com/butuzov/ireturn/cmd/ireturn
+go install github.com/butuzov/ireturn/cmd/ireturn@latest
 ```
 
 ### Compiled Binary


### PR DESCRIPTION
From Go 1.17 `go install` command does not allow installation without the version tag. In this PR I have fixed the issue.