### PR TITLE
Increase go version in go.mod to 1.18

### DIFF
--- a/analyzer/testdata/go.mod
+++ b/analyzer/testdata/go.mod
@@ -1,3 +1,3 @@
 module example
 
-go 1.17
+go 1.18


### PR DESCRIPTION
The Go module in the analyzer/testdata folder has a file `generics.go` which has Go code with generic types. Since this feature was added in Go 1.18, the go version in the go.mod file needs to be at least 1.18.

(I also want to note that the go version in the top module in this repo is 1.15. Maybe it's time to increase it? But that's another decision that should be made in another PR.)