### PR TITLE
dev: fix typos

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -27,7 +27,7 @@ type analyzer struct {
 	mu            sync.RWMutex
 	handler       validator
 	err           error
-	diabledNolint bool
+	disabledNolint bool
 
 	found []analysis.Diagnostic
 }
@@ -63,7 +63,7 @@ func (a *analyzer) run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		// 003. Is it allowed to be checked?
-		if !a.diabledNolint && hasDisallowDirective(f.Doc) {
+		if !a.disabledNolint && hasDisallowDirective(f.Doc) {
 			return
 		}
 
@@ -115,7 +115,7 @@ func (a *analyzer) readConfiguration(fs *flag.FlagSet) {
 	// First: checking nonolint directive
 	val := fs.Lookup("nonolint")
 	if val != nil {
-		a.diabledNolint = fs.Lookup("nonolint").Value.String() == "true"
+		a.disabledNolint = fs.Lookup("nonolint").Value.String() == "true"
 	}
 
 	// Second: validators implementation next

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -71,7 +71,7 @@ func TestAll(t *testing.T) {
 
 	tests = append(tests, testCase{
 		name: "anonymous Interface/allow",
-		mask: []string{"anonymous_interafce.go", "go.*"},
+		mask: []string{"anonymous_interface.go", "go.*"},
 		meta: map[string]string{
 			"allow": types.NameAnon,
 		},
@@ -80,12 +80,12 @@ func TestAll(t *testing.T) {
 
 	tests = append(tests, testCase{
 		name: "anonymous Interface/reject",
-		mask: []string{"anonymous_interafce.go", "go.*"},
+		mask: []string{"anonymous_interface.go", "go.*"},
 		meta: map[string]string{
 			"reject": types.NameAnon,
 		},
 		want: []string{
-			"NewanonymousInterface returns interface (anonymous interface)",
+			"NewAnonymousInterface returns interface (anonymous interface)",
 		},
 	})
 
@@ -278,7 +278,7 @@ func TestAll(t *testing.T) {
 			"allow": types.NameStdLib, // allow only interfaces from standard library (e.g. io.Writer, fmt.Stringer)
 		},
 		want: []string{
-			"NewanonymousInterface returns interface (anonymous interface)",
+			"NewAnonymousInterface returns interface (anonymous interface)",
 			"dissAllowDirective2 returns interface (interface{})",
 			"dissAllowDirective6 returns interface (interface{})",
 			"fooInterface returns interface (interface{})",
@@ -333,7 +333,7 @@ func TestAll(t *testing.T) {
 			"allow": types.NameGeneric, // allow only generic interfaces
 		},
 		want: []string{
-			"NewanonymousInterface returns interface (anonymous interface)",
+			"NewAnonymousInterface returns interface (anonymous interface)",
 			"dissAllowDirective2 returns interface (interface{})",
 			"dissAllowDirective6 returns interface (interface{})",
 			"fooInterface returns interface (interface{})",

--- a/analyzer/internal/config/allow.go
+++ b/analyzer/internal/config/allow.go
@@ -2,7 +2,7 @@ package config
 
 import "github.com/butuzov/ireturn/analyzer/internal/types"
 
-// allowConfig specifies a list of interfaces (keywords, patters and regular expressions)
+// allowConfig specifies a list of interfaces (keywords, patterns and regular expressions)
 // that are allowed by ireturn as valid to return, any non listed interface are rejected.
 type allowConfig struct {
 	*defaultConfig

--- a/analyzer/internal/config/reject.go
+++ b/analyzer/internal/config/reject.go
@@ -2,7 +2,7 @@ package config
 
 import "github.com/butuzov/ireturn/analyzer/internal/types"
 
-// rejectConfig specifies a list of interfaces (keywords, patters and regular expressions)
+// rejectConfig specifies a list of interfaces (keywords, patterns and regular expressions)
 // that are rejected by ireturn as valid to return, any non listed interface are allowed.
 type rejectConfig struct {
 	*defaultConfig

--- a/analyzer/std_test.go
+++ b/analyzer/std_test.go
@@ -19,7 +19,7 @@ func Test_isStdLib(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := isStdPkgInterface(name)
 			assert.Equal(t, got, want,
-				"pkg %s doens't match expectations (got %v vs want %v)", name, got, want)
+				"pkg %s doesn't match expectations (got %v vs want %v)", name, got, want)
 		})
 	}
 }

--- a/analyzer/testdata/anonymous_interface.go
+++ b/analyzer/testdata/anonymous_interface.go
@@ -4,7 +4,7 @@ type _t_anon_interface int
 
 func (t *_t_anon_interface) Do() {}
 
-func NewanonymousInterface() interface {
+func NewAnonymousInterface() interface {
 	Do()
 } {
 	t := _t_anon_interface(1)

--- a/analyzer/testdata/named_interfaces_simple.go
+++ b/analyzer/testdata/named_interfaces_simple.go
@@ -3,15 +3,15 @@ package example
 type (
 	iDoer         interface{}
 	iDoerAny      any
-	iDoerConcreat int
+	iDoerSpecific int
 )
 
 func newIDoer() iDoer {
-	return iDoerConcreat(0)
+	return iDoerSpecific(0)
 }
 
 func newIDoerAny() iDoerAny {
-	return iDoerConcreat(0)
+	return iDoerSpecific(0)
 }
 
 type Fooer interface {


### PR DESCRIPTION
The PR fixes typos in fields, file names, and tests.

`Concreat` should be `Concrete`. But I decided to rename to `Specific`, as it's a better name for this content (`Specific type`).