### PR TITLE
fix: nolint directives syntax

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,10 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: lint
-        uses: golangci/golangci-lint-action@v5.3.0
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-          skip-build-cache: true
-          skip-pkg-cache: true
-          args: -D deadcode --skip-dirs "^(cmd|testdata)"
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+linters:
+    enable:
+        - nolintlint
+        - gci
+        - gofumpt
+        - testifylint
+
+linters-settings:
+    nolintlint:
+        allow-unused: false
+        require-specific: true
+    gci:
+        sections:
+            - standard
+            - default
+            - prefix(github.com/butuzov/ireturn)
+
+output:
+    show-stats: true
+    sort-results: true
+    sort-order:
+        - linter
+        - file

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,13 @@ tests:
 		-coverprofile=coverage.cov ./...
 
 lints:
-	golangci-lint run --no-config ./... -D deadcode
+	golangci-lint run
 
 cover:
 	go tool cover -html=coverage.cov
+
+generate:
+	scripts/generate-std.sh
 
 install:
 	go install -trimpath -v -ldflags="-w -s" ./cmd/ireturn/

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/butuzov/ireturn/analyzer/internal/config"
-	"github.com/butuzov/ireturn/analyzer/internal/types"
-
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
+
+	"github.com/butuzov/ireturn/analyzer/internal/config"
+	"github.com/butuzov/ireturn/analyzer/internal/types"
 )
 
 const name string = "ireturn" // linter name
@@ -23,10 +23,10 @@ type validator interface {
 }
 
 type analyzer struct {
-	once          sync.Once
-	mu            sync.RWMutex
-	handler       validator
-	err           error
+	once           sync.Once
+	mu             sync.RWMutex
+	handler        validator
+	err            error
 	disabledNolint bool
 
 	found []analysis.Diagnostic
@@ -128,7 +128,7 @@ func (a *analyzer) readConfiguration(fs *flag.FlagSet) {
 }
 
 func NewAnalyzer() *analysis.Analyzer {
-	a := analyzer{} //nolint: exhaustivestruct
+	a := analyzer{}
 
 	return &analysis.Analyzer{
 		Name:     name,
@@ -196,7 +196,7 @@ func filterInterfaces(p *analysis.Pass, ft *ast.FuncType, di map[string]struct{}
 
 				typeParams := val.String()
 				prefix, suffix := "interface{", "}"
-				if strings.HasPrefix(typeParams, prefix) { // nolint: gosimple
+				if strings.HasPrefix(typeParams, prefix) { //nolint:gosimple
 					typeParams = typeParams[len(prefix):]
 				}
 				if strings.HasSuffix(typeParams, suffix) {

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -1,20 +1,17 @@
-//nolint: wrapcheck
-//nolint: exhaustivestruct
-
 package analyzer
 
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/butuzov/ireturn/analyzer/internal/types"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/butuzov/ireturn/analyzer/internal/types"
 )
 
 const testPackageName = "example"
@@ -478,9 +475,9 @@ func (tc testCase) xerox(root string) error {
 func cp(src, dst string) error {
 	if location, err := filepath.Abs(src); err != nil {
 		return err
-	} else if data, err := ioutil.ReadFile(location); err != nil {
+	} else if data, err := os.ReadFile(location); err != nil {
 		return err
-	} else if err := ioutil.WriteFile(filepath.Join(dst, filepath.Base(src)), data, 0o600); err != nil {
+	} else if err := os.WriteFile(filepath.Join(dst, filepath.Base(src)), data, 0o600); err != nil {
 		return err
 	}
 

--- a/analyzer/internal/config/new.go
+++ b/analyzer/internal/config/new.go
@@ -10,7 +10,6 @@ import (
 
 var ErrCollisionOfInterests = errors.New("can't have both `-accept` and `-reject` specified at same time")
 
-// nolint: exhaustivestruct
 func DefaultValidatorConfig() *allowConfig {
 	return allowAll([]string{
 		types.NameEmpty,  // "empty": empty interfaces (interface{})

--- a/analyzer/internal/types/iface.go
+++ b/analyzer/internal/types/iface.go
@@ -47,7 +47,7 @@ func (i IFace) HashString() string {
 }
 
 func (i IFace) ExportDiagnostic() analysis.Diagnostic {
-	return analysis.Diagnostic{ //nolint: exhaustivestruct
+	return analysis.Diagnostic{
 		Pos:     i.Pos,
 		Message: i.String(),
 	}

--- a/analyzer/std_test.go
+++ b/analyzer/std_test.go
@@ -18,7 +18,7 @@ func Test_isStdLib(t *testing.T) {
 		want, name := want, name
 		t.Run(name, func(t *testing.T) {
 			got := isStdPkgInterface(name)
-			assert.Equal(t, got, want,
+			assert.Equal(t, want, got,
 				"pkg %s doesn't match expectations (got %v vs want %v)", name, got, want)
 		})
 	}

--- a/analyzer/testdata/disallow_directive_ok.go
+++ b/analyzer/testdata/disallow_directive_ok.go
@@ -3,35 +3,35 @@ package example
 /*
 	Actual disallow directive.
 */
-//nolint: ireturn
+//nolint:ireturn
 func dissAllowDirective1() interface{} { return 1 }
 
 /*
 	Some other linter in disallow directive.
 */
-//nolint: ireturn1
+//nolint:return1
 func dissAllowDirective2() interface{} { return 1 }
 
 /*
 	Coma separate linters in nolint directive. golangci-lint compatible mode
 */
-//nolint: ireturn, nocode
+//nolint:ireturn,nocode
 func dissAllowDirective3() interface{} { return 1 }
 
 /*
 	Example of the good example if interlapsing name and actual ireturn with dot at the end.
 */
-//nolint: ireturnlong, ireturn.
+//nolint:ireturnlong,ireturn.
 func dissAllowDirective4() interface{} { return 1 }
 
 /*
 	Example of the good example if interlapsing name and actual ireturn with dot at the end.
 */
-//nolint: ireturnlong, ireturn
+//nolint:ireturnlong,ireturn
 func dissAllowDirective5() interface{} { return 1 }
 
 /*
 	Not works!
 */
-//nolint: ireturnlong, itertut ireturn1.
+//nolint:ireturnlong,itertutireturn1.
 func dissAllowDirective6() interface{} { return 1 }

--- a/cmd/ireturn/main.go
+++ b/cmd/ireturn/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/butuzov/ireturn/analyzer"
 	"golang.org/x/tools/go/analysis/singlechecker"
+
+	"github.com/butuzov/ireturn/analyzer"
 )
 
 func main() {

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ You can use shorthand for some types of interfaces:
 
 ### Disable directive
 
-`golangci-lint` compliant disable directive `//nolint: ireturn` can be used with `ireturn`
+`golangci-lint` compliant disable directive `//nolint:ireturn` can be used with `ireturn`
 
 ### GitHub Action
 


### PR DESCRIPTION
- fix nolint directives syntax `[a-z]+:[a-z].+`
- remove unused nolint directives
- add a simple golangci-lint configuration
